### PR TITLE
Function Follow Controls

### DIFF
--- a/examples/sample-game/SampleGame.cpp
+++ b/examples/sample-game/SampleGame.cpp
@@ -208,23 +208,28 @@ int main() {
     std::unique_ptr<ecs::CameraFollow> camera_follow = std::make_unique<ecs::CameraFollow>(trans_comp_manager, camera_comp_manager);
     
     // Prepare free controls for the camera guide
-    controls::TopDownControls::Controls controls_config {
-//            .forward = input::unified_input::keyboard(GLFW_KEY_W),
-//            .backward = input::unified_input::keyboard(GLFW_KEY_S),
+    controls::FunctionFollowControls::Controls controls_config {
+            .forward = input::unified_input::keyboard(GLFW_KEY_W),
+            .backward = input::unified_input::keyboard(GLFW_KEY_S),
             .left = input::unified_input::keyboard(GLFW_KEY_A),
             .right = input::unified_input::keyboard(GLFW_KEY_D),
-            .up = input::unified_input::keyboard(GLFW_KEY_LEFT_SHIFT),
-            .down = input::unified_input::keyboard(GLFW_KEY_LEFT_CONTROL),
-            .clockwise = input::unified_input::keyboard(GLFW_KEY_Q),
-            .counter_clockwise = input::unified_input::keyboard(GLFW_KEY_E),
+            .orbit_left = input::unified_input::keyboard(GLFW_KEY_Q),
+            .orbit_right = input::unified_input::keyboard(GLFW_KEY_E),
+//            .up = input::unified_input::keyboard(GLFW_KEY_LEFT_SHIFT),
+//            .down = input::unified_input::keyboard(GLFW_KEY_LEFT_CONTROL),
+//            .clockwise = input::unified_input::keyboard(GLFW_KEY_Q),
+//            .counter_clockwise = input::unified_input::keyboard(GLFW_KEY_E),
 //            .turn = input::unified_input::mouse(GLFW_MOUSE_BUTTON_RIGHT),
             .speed_x = 150.0f,
-//            .speed_z = 150.0f,
-            .speed_y = 150.0f,
+            .speed_z = 150.0f,
+//            .speed_y = 150.0f,
 //            .turn_rate = 0.3f,
-            .roll_rate = 30.0f
+//            .roll_rate = 30.0f
+            .orbit_rate = 90.0f,
+            .parameter_rate = 1.0f,
     };
-    std::unique_ptr<controls::TopDownControls> controls = std::make_unique<controls::TopDownControls>(trans_comp_manager, camera_guide, controls_config);
+    std::unique_ptr<controls::FunctionFollowControls> controls = std::make_unique<controls::FunctionFollowControls>(
+            trans_comp_manager, camera_guide, controls_config, [](float p){ return p*p; }, [](float p){ return p;});
 
     // Set background to black
     glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
@@ -234,16 +239,13 @@ int main() {
     glDepthFunc(GL_LESS);
 
     // Update cursor delta once before main loop to avoid extreme first cursor delta
-    input::update_cursor_delta();
+//    input::update();
 
     // Loop until the user closes the window
     open_sea::time::start_delta();
     while (!window::should_close()) {
         // Clear
         glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-
-        // Update cursor delta
-        input::update_cursor_delta();
 
         // Update camera guide controls
         controls->transform();
@@ -286,6 +288,10 @@ int main() {
                 ImGui::Begin("Test controls");
 
                 ImGui::Checkbox("Use perspective camera", &use_per_cam);
+
+                ImGui::Text("Controls pos: %.3f, %.3f, %.3f", controls->origin.x, controls->origin.y, controls->origin.z);
+                ImGui::Text("Controls orbit: %.3f", controls->orbit);
+                ImGui::Text("Controls parameter: %.3f", controls->parameter);
 
 //                ImGui::Text("Camera want turn: %s", (camera_want_turn) ? "true" : "false");
 //                ImGui::Text("Cursor delta: %.3f, %.3f", cursor_delta.x, cursor_delta.y);
@@ -346,6 +352,9 @@ int main() {
             //Render
             imgui::render();
         }
+
+        // Update input
+        input::update();
 
         // Update the window
         window::update();

--- a/include/open-sea/Controls.h
+++ b/include/open-sea/Controls.h
@@ -168,6 +168,76 @@ namespace open_sea::controls {
             void showDebug();
     };
 
+    /** \class FunctionFollowControls
+     * \brief Controls an entity using function following controls
+     * Controls an entity using function following controls.
+     * Exact subject position and orientation controlled by function and orbit.
+     * Subject position is (p, f(p), 0) rotated by orbit around Y axis.
+     * Subject orientation is down the function (\c -f'(p)).
+     * Parameter control using scroll input.
+     * Position control (of function origin) in XZ plane without restriction through unified input.
+     * Orbit (yaw) control through unified input.
+     * Initial orbit is -90 degrees (suitable to control camera guide with p increasing behind camera view).
+     * Only one entity should be controlled at one time.
+     */
+    //TODO: allow initialisation with other origin and parameter than 0s (read origin from subject?)
+    class FunctionFollowControls {
+        public:
+            //! Type of the function
+            typedef float (*function_t)(float);
+
+//        private:
+            //! Entity being controlled
+            ecs::Entity subject;
+            //! Function origin
+            glm::vec3 origin;
+            //! Function for Y calculation
+            function_t function;
+            //! First derivative of function
+            function_t slope;
+            //! Function parameter
+            float parameter;
+            //! Orbit in degrees
+            float orbit;
+
+        public:
+            //! Transformation component manager
+            std::shared_ptr<ecs::TransformationComponent> transformMgr{};
+            //! Key bindings and factors
+            struct Controls {
+                // Key bindings
+                input::unified_input forward;
+                input::unified_input backward;
+                input::unified_input left;
+                input::unified_input right;
+                input::unified_input orbit_right;   // Positive sense
+                input::unified_input orbit_left;    // Negative sense
+
+                // Factors
+                //! Left-right (strafing) speed in (units / second)
+                float speed_x;
+                //! Forward-backward speed (units / second)
+                float speed_z;
+                //! Degrees per second
+                float orbit_rate;
+                //! Parameter change rate (1 / scroll units)
+                float parameter_rate;
+            } controls;
+
+
+            //! Constuct the controls assigning it a pointer to the relevant transformation component manager, subject, controls, and functions.
+            FunctionFollowControls(std::shared_ptr<ecs::TransformationComponent> t, ecs::Entity s, Controls c,
+                                   function_t f, function_t d)
+                    : transformMgr(std::move(t)), subject(s), controls(c), function(f), slope(d), parameter(0.0f),
+                      orbit(90.0f), origin({0.0f, 0.0f, 0.0f}) {}
+
+            void transform();
+            void setSubject(ecs::Entity newSubject);
+            ecs::Entity getSubject();
+
+            void showDebug();
+    };
+
 };
 
 #endif //OPEN_SEA_CONTROLS_H

--- a/include/open-sea/Input.h
+++ b/include/open-sea/Input.h
@@ -81,6 +81,8 @@ namespace open_sea::input {
     ::glm::dvec2 cursor_position();
     glm::dvec2 cursor_delta();
     void update_cursor_delta();
+    glm::dvec2 get_scroll();
+    void update();
     state key_state(int key);
     state mouse_state(int button);
     std::string key_name(int key, int scancode);

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -221,9 +221,6 @@ namespace open_sea::window {
     void update() {
         // Swap front and back buffers
         ::glfwSwapBuffers(window::window);
-
-        // Poll for and process events
-        ::glfwPollEvents();
     }
 
     /**


### PR DESCRIPTION
This pull request contains experimental controls that were supposed to follow a function to simulate camera movement similar to games like Cities Skylines. That camera is a perspective camera where zooming in moves the camera down, forward, and changes its orientation. My implementation doesn't work well, but I might fix it one day. Till then it will reside in this branch.